### PR TITLE
Add .pre-commit-hooks.yaml for auto-inserting markdown

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,8 @@
       - '--between'
       - "<!-- generated env. vars. start -->"
       - "<!-- generated env. vars. end -->"
-      - '--heading-offset 1'
+      - '--heading-offset'
+      - '1'
     language: python
     types: [file, python]
     pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,5 +8,6 @@
       - '--between "<!-- generated env. vars. start -->" "<!-- generated env. vars. end -->"'
       - '--heading-offset 1'
     language: python
+    language_version: python3.8
     types: [file, python]
     pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,12 @@
+-   id: insert-settings-doc-md
+    name: insert settings-doc markdown
+    description: This hook inserts settings-doc generated markdown to a file.
+    entry: settings-doc generate --output-format markdown
+    args:
+      - '--module src.settings'
+      - '--update README.md'
+      - '--between "<!-- generated env. vars. start -->" "<!-- generated env. vars. end -->"'
+      - '--heading-offset 1'
+    language: python
+    types: [file, python]
+    pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,11 +3,14 @@
     description: This hook inserts settings-doc generated markdown to a file.
     entry: settings-doc generate --output-format markdown
     args:
-      - '--module src.settings'
-      - '--update README.md'
-      - '--between "<!-- generated env. vars. start -->" "<!-- generated env. vars. end -->"'
+      - '--module'
+      - 'src.settings'
+      - '--update'
+      - 'README.md'
+      - '--between'
+      - "<!-- generated env. vars. start -->"
+      - "<!-- generated env. vars. end -->"
       - '--heading-offset 1'
     language: python
-    language_version: python3.8
     types: [file, python]
     pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Example `.pre-commit-config.yaml` section provided below:
         - '--heading-offset'
         - '1'
       additional_dependencies:
-       - "pyyaml>=5.3.1"
+        - "pyyaml>=5.3.1"
 ```
 
 # Features overview

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ It is powered by the [Jinja2](https://jinja.palletsprojects.com/en/latest/) temp
 - [Advanced usage](#advanced-usage)
   - [Custom templates](#custom-templates)
   - [Custom settings attributes in templates](#custom-settings-attributes-in-templates)
+  - [As a pre-commit hook](#as-a-pre-commit-hook)
 - [Features overview](#features-overview)
   - [Markdown](#markdown)
   - [.env](#env)
@@ -256,6 +257,38 @@ To access information from the `BaseSettings` classes, use the `classes` variabl
 {% for cls, fields in classes.items() %}
 # {{ cls.__name__ }}
 {% endfor %}
+```
+
+## As a pre-commit hook
+
+It's possible to use `settings-doc` as a pre-commit hook, however, that requires some careful fine-tuning.
+
+1. You have to provide *all* the arguments (except `--output-format markdown`) in the `args` section,
+unless, by some extraordinary strike of luck, your settings are already located at `src.settings` module.
+2. You have to provide `additional_dependencies`, specifing each package, that is imported in
+your module. For example, if you use yaml-loading for your settings, and you have `import yaml` in
+your module, you have to specify it. Depending on how your imports are organized, you might need to
+specify *all* of your dependencies.
+
+Example `.pre-commit-config.yaml` section provided below:
+
+```yaml
+- repo: https://github.com/radeklat/settings-doc
+  rev: '3.0.0'
+  hooks:
+    - id: insert-settings-doc-md
+      args:
+        - '--module'
+        - 'src.settings'
+        - '--update'
+        - 'README.md'
+        - '--between'
+        - "<!-- generated env. vars. start -->"
+        - "<!-- generated env. vars. end -->"
+        - '--heading-offset'
+        - '1'
+      additional_dependencies:
+       - "pyyaml>=5.3.1"
 ```
 
 # Features overview


### PR DESCRIPTION
Here's a stab at making this repo a pre-commit hook.

Notes:

1. Please *do* squash commits if/when you merge, source branch is pretty dirty.
2. Not sure how to properly test this.
3. If this gets merged, a future version of `settings-doc` will likely have to tinker with the default values or provide some other conveniences to make it simpler to configure this hook **without** redefining all the `args`.
4. For the meantime, I've tried to explain all the caveats in the README.
5. This **does** indeed work, already using it :)

Some comments on picked settings:

- `types: [file, python]` - we want this hook triggered by any change to any python file
- hook *users* might override this by specifying desired files/regexps/whatever, this is standard pre-commit usage, so not worth mentioning in the README, IMHO.
- `pass_filenames: false` - because `settings-docs` does not operate on file names, but uses class-paths or modules in pythonic notation, we do not want to bog it with filenames.

Ideas for future settings-doc improvements:

(Sadly I can't do it myself *yet*, but hopefully you would consider this)

- allow setting-docs to receive filenames, e.g. `settings-doc [OPTIONS] FILE1 FILE2 FILEN` instead of module/class paths
- add sensible defaults for each option, most importantly `--between`, so that people wouldn't need to override this (might already be the case, haven't really checked).

This will potentially simplify hook usage to something like:

```
- repo: https://github.com/radeklat/settings-doc
  rev: '3.0.0'
  hooks:
    - id: insert-settings-doc-md
      args:
        - '--update'
        - 'README.md'
        - '--heading-offset'
        - '1'
      files: 'src/settings.py`
```
