### PR TITLE
Add support for env_prefix config setting

### DIFF
--- a/src/settings_doc/main.py
+++ b/src/settings_doc/main.py
@@ -68,7 +68,7 @@ def _model_fields(settings: Set[Type[BaseSettings]]) -> Iterator[Tuple[str, Fiel
                 else:
                     LOGGER.error(f"Unsupported validation alias type '{type(model_field.validation_alias)}'.")
             else:
-                yield field_name, model_field
+                yield cls.model_config["env_prefix"] + field_name, model_field
 
 
 @app.command()

--- a/tests/fixtures/valid_settings.py
+++ b/tests/fixtures/valid_settings.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from pydantic import AliasChoices, AliasPath, Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 SETTINGS_ATTR = "logging_level"
 SETTINGS_MARKDOWN_FIRST_LINE = f"# `{SETTINGS_ATTR}`\n"
@@ -64,3 +64,9 @@ class ValidationAliasPathSettings(BaseSettings):
 
 class ValidationAliasChoicesSettings(BaseSettings):
     logging_level: str = Field(..., validation_alias=AliasChoices("logging", "level"))
+
+
+class EnvPrefixSettings(BaseSettings):
+    logging_level: str
+
+    model_config = SettingsConfigDict(env_prefix="PREFIX_")

--- a/tests/integration/generate/test_import_module_path.py
+++ b/tests/integration/generate/test_import_module_path.py
@@ -9,6 +9,7 @@ from settings_doc.importing import import_module_path
 from tests.fixtures.module_with_single_settings_class import SingleSettingsInModule
 from tests.fixtures.valid_settings import (
     EmptySettings,
+    EnvPrefixSettings,
     ExamplesSettings,
     FullSettings,
     MultipleSettings,
@@ -44,6 +45,7 @@ class TestImportModulePath:
                     ValidationAliasPathSettings,
                     ValidationAliasChoicesSettings,
                     ExamplesSettings,
+                    EnvPrefixSettings,
                 },
                 id="for a module with multiple matching classes",
             ),
@@ -60,6 +62,7 @@ class TestImportModulePath:
                     ValidationAliasPathSettings,
                     ValidationAliasChoicesSettings,
                     ExamplesSettings,
+                    EnvPrefixSettings,
                 },
                 id="for multiple modules with multiple matching classes",
             ),

--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -11,6 +11,7 @@ from tests.fixtures.invalid_settings import ExamplesNotIterableSettings
 from tests.fixtures.valid_settings import (
     SETTINGS_MARKDOWN_FIRST_LINE,
     EmptySettings,
+    EnvPrefixSettings,
     ExamplesSettings,
     FullSettings,
     MultipleSettings,
@@ -199,3 +200,8 @@ class TestMarkdownFormat:
     def should_end_with_a_single_empty_line(runner: CliRunner, mocker: MockerFixture):
         stdout = run_app_with_settings(mocker, runner, MultipleSettings)
         assert not stdout.endswith("`\n\n"), f"'{stdout}' ends with empty line"
+
+    @staticmethod
+    def should_include_env_prefix(runner: CliRunner, mocker: MockerFixture):
+        expected_string = "# `prefix_logging_level`\n\n**required**\n\n"
+        assert run_app_with_settings(mocker, runner, EnvPrefixSettings) == expected_string


### PR DESCRIPTION
This adds support for the env_prefix config setting by prepending the prefix to the field name.