### PR TITLE
Fix module/class not found error

### DIFF
--- a/src/settings_doc/main.py
+++ b/src/settings_doc/main.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import itertools
 import logging
+import os
 import re
 import shutil
+import sys
 from enum import Enum, auto
 from inspect import isclass
 from os import listdir
@@ -25,7 +27,9 @@ LOGGER = logging.getLogger(__name__)
 
 @click.group()
 def app():
-    pass
+    # add current working directory relative
+    # to where the settings-docs command started
+    sys.path.append(os.getcwd())
 
 
 class OutputFormat(Enum):


### PR DESCRIPTION
When following the docs,
```
settings-doc generate --class src.settings.AppSettings --output-format markdown
Usage: settings-doc generate [OPTIONS]
Try 'settings-doc generate --help' for help.

Error: Invalid value for '--class' / '-c': Cannot read the settings class: No module named 'src'
```

Folder structure:
```
.
└── src/
    ├── __init__.py
    └── settings.py
  ```
  
  settings.py
  ```py
  from pydantic_settings import BaseSettings


class AppSettings(BaseSettings):
    logging_level: str
```