### PR TITLE
Handle AliasChoices in validation_alias for settings

### DIFF
--- a/src/settings_doc/main.py
+++ b/src/settings_doc/main.py
@@ -12,7 +12,7 @@ from typing import Final, Iterator
 
 import click
 from jinja2 import Environment, FileSystemLoader, Template, select_autoescape
-from pydantic import BaseModel
+from pydantic import AliasChoices, BaseModel
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings
 
@@ -50,8 +50,19 @@ def _model_fields_recursive(
         if model_field.validation_alias is not None:
             if isinstance(model_field.validation_alias, str):
                 yield model_field.validation_alias, model_field
+            elif (
+                isinstance(model_field.validation_alias, AliasChoices)
+                and len(model_field.validation_alias.choices) > 0
+                and isinstance(model_field.validation_alias.choices[0], str)
+            ):
+                # Validation alias is an AliasChoices object, which can be used to generate multiple aliases.
+                # The constructor for AliasChoices ensures that the first element is preferred via kwarg "first_choice".
+                yield model_field.validation_alias.choices[0], model_field
             else:
-                LOGGER.error(f"Unsupported validation alias type '{type(model_field.validation_alias)}'.")
+                LOGGER.error(
+                    f"Unsupported validation alias type '{type(model_field.validation_alias)}' in "
+                    f"{cls.__name__}.{field_name}.",
+                )
         elif isclass(model_field.annotation) and issubclass(model_field.annotation, BaseModel):
             # There are nested fields and they can be joined by a delimiter. Generate variable names recursively.
             if issubclass(model_field.annotation, BaseSettings):

--- a/tests/fixtures/valid_settings.py
+++ b/tests/fixtures/valid_settings.py
@@ -64,7 +64,13 @@ class ValidationAliasPathSettings(BaseSettings):
 
 
 class ValidationAliasChoicesSettings(BaseSettings):
-    logging_level: str = Field(..., validation_alias=AliasChoices("logging", "level"))
+    logging_level: str = Field(..., validation_alias=AliasChoices("logging_level", "log_level"))
+
+
+class ValidationAliasChoicesWithAliasPathSettings(BaseSettings):
+    logging_level: str = Field(
+        validation_alias=AliasChoices(AliasPath("logging_level", 0), "log_level"),
+    )
 
 
 class EnvPrefixSettings(BaseSettings):

--- a/tests/integration/generate/test_import_module_path.py
+++ b/tests/integration/generate/test_import_module_path.py
@@ -22,6 +22,7 @@ from tests.fixtures.valid_settings import (
     SettingsWithSettingsSubModel,
     SettingsWithSettingsSubModelNoPrefixOrDelimiter,
     ValidationAliasChoicesSettings,
+    ValidationAliasChoicesWithAliasPathSettings,
     ValidationAliasPathSettings,
     ValidationAliasSettings,
 )
@@ -50,6 +51,7 @@ class TestImportModulePath:
                     ValidationAliasSettings: None,
                     ValidationAliasPathSettings: None,
                     ValidationAliasChoicesSettings: None,
+                    ValidationAliasChoicesWithAliasPathSettings: None,
                     ExamplesSettings: None,
                     EnvPrefixSettings: None,
                     EnvNestedDelimiterSettings: None,
@@ -73,6 +75,7 @@ class TestImportModulePath:
                     ValidationAliasSettings: None,
                     ValidationAliasPathSettings: None,
                     ValidationAliasChoicesSettings: None,
+                    ValidationAliasChoicesWithAliasPathSettings: None,
                     ExamplesSettings: None,
                     EnvPrefixSettings: None,
                     EnvNestedDelimiterSettings: None,

--- a/tests/unit/test_dotenv.py
+++ b/tests/unit/test_dotenv.py
@@ -19,6 +19,7 @@ from tests.fixtures.valid_settings import (
     SettingsWithSettingsSubModel,
     SettingsWithSettingsSubModelNoPrefixOrDelimiter,
     ValidationAliasChoicesSettings,
+    ValidationAliasChoicesWithAliasPathSettings,
     ValidationAliasPathSettings,
     ValidationAliasSettings,
 )
@@ -31,6 +32,9 @@ class TestDotEnvFormat:
         "expected_string, settings_class",
         [
             pytest.param(f"{SETTINGS_ATTR}=\n", ValidationAliasSettings, id="validation alias with required value"),
+            pytest.param(
+                f"{SETTINGS_ATTR}=\n", ValidationAliasChoicesSettings, id="validation alias with first value in choices"
+            ),
             pytest.param(
                 f"{SETTINGS_ATTR}=some_value\n\n", FullSettings, id="variable name with optional default value"
             ),
@@ -90,7 +94,7 @@ class TestDotEnvFormat:
         "settings_class",
         [
             pytest.param(ValidationAliasPathSettings, id="validation AliasPath"),
-            pytest.param(ValidationAliasChoicesSettings, id="validation AliasChoices"),
+            pytest.param(ValidationAliasChoicesWithAliasPathSettings, id="validation AliasChoices"),
         ],
     )
     def should_log_error_for(

--- a/tests/unit/test_markdown.py
+++ b/tests/unit/test_markdown.py
@@ -23,6 +23,7 @@ from tests.fixtures.valid_settings import (
     SettingsWithSettingsSubModel,
     SettingsWithSettingsSubModelNoPrefixOrDelimiter,
     ValidationAliasChoicesSettings,
+    ValidationAliasChoicesWithAliasPathSettings,
     ValidationAliasPathSettings,
     ValidationAliasSettings,
 )
@@ -36,6 +37,9 @@ class TestMarkdownFormat:
         [
             pytest.param(f"{SETTINGS_MARKDOWN_FIRST_LINE}\n", FullSettings, id="variable name"),
             pytest.param(f"{SETTINGS_MARKDOWN_FIRST_LINE}\n", ValidationAliasSettings, id="validation alias"),
+            pytest.param(
+                f"{SETTINGS_MARKDOWN_FIRST_LINE}\n", ValidationAliasChoicesSettings, id="validation alias with choices"
+            ),
             pytest.param("\n\n*optional*, ", FullSettings, id="optional flag"),
             pytest.param(", default value: `some_value`\n\n", FullSettings, id="default value"),
             pytest.param("\n\nuse fullsettings like this\n\n", FullSettings, id="description"),
@@ -141,7 +145,7 @@ class TestMarkdownFormat:
         "settings_class",
         [
             pytest.param(ValidationAliasPathSettings, id="validation AliasPath"),
-            pytest.param(ValidationAliasChoicesSettings, id="validation AliasChoices"),
+            pytest.param(ValidationAliasChoicesWithAliasPathSettings, id="validation AliasChoices"),
         ],
     )
     def should_log_error_for(

--- a/tests/unit/test_render.py
+++ b/tests/unit/test_render.py
@@ -5,7 +5,12 @@ from pydantic_settings import BaseSettings
 from pytest_mock import MockerFixture
 
 from settings_doc import OutputFormat, render
-from tests.fixtures.valid_settings import SETTINGS_ATTR, FullSettings, ValidationAliasSettings
+from tests.fixtures.valid_settings import (
+    SETTINGS_ATTR,
+    FullSettings,
+    ValidationAliasChoicesSettings,
+    ValidationAliasSettings,
+)
 from tests.helpers import mock_import_class_path, mock_import_module_path
 
 
@@ -15,6 +20,7 @@ class TestRenderDotEnvFormat:
         "expected_string, settings_class",
         [
             pytest.param(f"{SETTINGS_ATTR}=\n", ValidationAliasSettings, id="validation alias with required value"),
+            pytest.param(f"{SETTINGS_ATTR}=\n", ValidationAliasChoicesSettings, id="validation alias with choices"),
             pytest.param(
                 f"{SETTINGS_ATTR}=some_value\n\n", FullSettings, id="variable name with optional default value"
             ),


### PR DESCRIPTION
- Support for `AliasChoices` objects in `validation_alias`, yielding the first choice as the preferred alias. 
  - The first, and presumably preferred alias, is [guaranteed by pydantic](https://github.com/pydantic/pydantic/blob/f7a9b73517afecf25bf898e3b5f591dffe669778/pydantic/aliases.py#L71) to be the first element of the choices list. Assuming it is in fact a string, this presumably would be a valid default value for most use cases. 
  - I considered, and dismissed, the idea of seeking the first instance of a `str`, but I suspect that that may lead to surprising behavior for existing users of the library. For example, if the first and common/primary alias is an `AliasPath`, then emitting a secondary alias might end up being unexpected or undesired. As resolving AliasPaths is probably outside of the scope of settings-doc due to the inherent complexity, and existing users likely accept this limitation, I think it is preferable to only emit a value when the *first* element is a `str`.
- Adds new test cases and fixtures for `AliasChoices` and `AliasPath` combinations to ensure intended behavior and continued error logging in the case that an `AliasPath` is the first member of the `AliasChoice` list.
  - Changes the existing `validation_alias` for `ValidationAliasChoicesSettings.logging_level` to be  consistent with the pattern in the testing objects for other `validation_alias`, especially the parametrized fixtures.
- Adjusted the relevant error message to print the causing object and field, which may help in conveying to users of the library what is causing the message and highlights which objects are not supported for aliases.

This PR is made with full ignorance to what the exact reasons were to not support `AliasChoices` in the first place. I couldn't come up with a compelling reason why, but I recognize there may be good cause for not supporting it. It is fairly obvious that there was a conscious reason at the time, considering lack of support is explicitly tested for. In the case I've overlooked something in either the code submitted or my underlying reasoning for the PR, please feel free to let me know and I'll be happy to address.